### PR TITLE
FIX: fixed typo on session close 

### DIFF
--- a/towtruck/visibilityApi.js
+++ b/towtruck/visibilityApi.js
@@ -31,7 +31,7 @@ define(["session"], function (session) {
   });
 
   session.on("close", function () {
-    document.removeListener(visibilityChange, change, false);
+    document.removeEventListener(visibilityChange, change, false);
   });
 
   function change() {


### PR DESCRIPTION
fix an exception on session closing due to a small typo.
(document.removeListener should be document.removeEventListener)
