### PR TITLE
Export set of trackers on TowTruck.

### DIFF
--- a/towtruck/forms.js
+++ b/towtruck/forms.js
@@ -65,7 +65,7 @@ define(["jquery", "util", "session", "elementFinder", "eventMaker", "templating"
     return false;
   }
 
-  var editTrackers = {};
+  var editTrackers = TowTruck.trackers = {};
   var liveTrackers = [];
 
   var AceEditor = util.Class({


### PR DESCRIPTION
This lets a 3rd party add a new tracker for a specific type of page
content.
