### PR TITLE
Ensure trackers' change monitors are deregistered when TowTruck is closed

### DIFF
--- a/towtruck/forms.js
+++ b/towtruck/forms.js
@@ -451,6 +451,8 @@ define(["jquery", "util", "session", "elementFinder", "eventMaker", "templating"
 
   session.on("ui-ready", setInit);
 
+  session.on("close", destroyTrackers);
+
   session.hub.on("form-init", function (msg) {
     if (! msg.sameUrl) {
       return;


### PR DESCRIPTION
One more little bug w/ tracker support.
