### PR TITLE
HUB: Use 'crypto' package for random HEX gen; generalise countClients method; cleanup type coercive comparators 

### DIFF
--- a/hub/server.js
+++ b/hub/server.js
@@ -16,11 +16,6 @@ if ( process.env.NEW_RELIC_HOME ) {
 var SAMPLE_STATS_INTERVAL = 60*1000; // 1 minute
 var EMPTY_ROOM_LOG_TIMEOUT = 3*60*1000; // 3 minutes
 
-var WebSocketServer = require('websocket').server;
-var WebSocketRouter = require('websocket').router;
-var http = require('http');
-var parseUrl = require('url').parse;
-
 // FIXME: not sure what logger to use
 //var logger = require('../../lib/logger');
 


### PR DESCRIPTION
- I added the core Node `crypto` package as a dependency (requiring Node >0.6) and have implemented it in the `generareId` method. Generating randomness is hard, let the kernel do it where it's been tested extensively.
- I generalised the 'countClients' method into a 'countObj' method, as it's being used for other things besides counting clients. I also refactored it to use `Object.keys(count).length' as it'll be faster than iterating over the object and incrementing a counter.
- I also removed all the bad comparators, now no comparator is coercing type: `!==` not `!=` and `===` not `==`

I've working on a much larger refactor of this hub code at the moment, this was just the long hanging fruit.

Awesome project btw!
