### PR TITLE
Nest input[type="checkbox"] inside .togetherjs-window, fixes overriding ...

### DIFF
--- a/togetherjs/togetherjs.less
+++ b/togetherjs/togetherjs.less
@@ -992,8 +992,10 @@ section.togetherjs-participant-window-main {
   float: left;
 }
 
-.togetherjs-window input[type="radio"], input[type="checkbox"] {
-  margin: 0px 0 0 !important;
+.togetherjs-window {
+	input[type="radio"], input[type="checkbox"] {
+  		margin: 0 0 0 !important;
+	}
 }
 
 .togetherjs-clear {


### PR DESCRIPTION
...parent page stylesheet.
