### PR TITLE
Fix textarea selection change

### DIFF
--- a/togetherjs/forms.js
+++ b/togetherjs/forms.js
@@ -362,9 +362,9 @@ define(["jquery", "util", "session", "elementFinder", "eventMaker", "templating"
       return;
     }
     var text = isText(el);
-    var selection;
-    if (text) {
-      selection = [el[0].selectionStart, el[0].selectionEnd];
+    var elFocused = (el[0] == el[0].ownerDocument.activeElement); 
+    if (text && elFocused) {
+      var selection = [el[0].selectionStart, el[0].selectionEnd];
     }
     var value;
     if (msg.replace) {
@@ -373,7 +373,9 @@ define(["jquery", "util", "session", "elementFinder", "eventMaker", "templating"
         console.warn("form update received for uninitialized form element");
         return;
       }
-      history.setSelection(selection);
+      if (elFocused) {	
+        history.setSelection(selection);
+      }
       // make a real TextReplace object.
       msg.replace.delta = ot.TextReplace(msg.replace.delta.start,
                                          msg.replace.delta.del,
@@ -385,14 +387,16 @@ define(["jquery", "util", "session", "elementFinder", "eventMaker", "templating"
         return;
       }
       value = history.current;
-      selection = history.getSelection();
+      if (elFocused) {	
+        selection = history.getSelection();
+      }
     } else {
       value = msg.value;
     }
     inRemoteUpdate = true;
     try {
       setValue(el, value);
-      if (text) {
+      if (text && elFocused) { 
         el[0].selectionStart = selection[0];
         el[0].selectionEnd = selection[1];
       }


### PR DESCRIPTION
Issue #797:
The behavior is caused by the code responsible for preserving user selection.
It seems that setting selectionStart  and SelectionEnd propoerties of a textbox set also focus on that input. So, when a user is editing a textbox1 and an update-form request for textbox2 arrived, the cursor will moves automatically to textbox2 causing a text mess. ( This happens on chrome and not in Firefox (didn't check it on safari and IE))

What I did is just make sure that the element being modified by remote users is focused  locally before saving and restoring user selection, this will make sure that the users are editing the same textbox or textarea(otherwise, it is not necessary).
