### PR TITLE
Add a guard before deref history.

### DIFF
--- a/togetherjs/forms.js
+++ b/togetherjs/forms.js
@@ -37,10 +37,10 @@ define(["jquery", "util", "session", "elementFinder", "eventMaker", "templating"
     };
     if (isText(el)) {
       var history = el.data("togetherjsHistory");
-      if (history.current == value) {
-        return;
-      }
       if (history) {
+        if (history.current == value) {
+          return;
+        }
         var delta = ot.TextReplace.fromChange(history.current, value);
         assert(delta);
         history.add(delta);


### PR DESCRIPTION
There were certain cases causing togetherjs to break
here when history would be undefined. This was caused
by, for instance, when text in a text box were changed
by script.
