### PR TITLE
prevent configuration loading when closing TogetherJS

### DIFF
--- a/togetherjs/togetherjs.js
+++ b/togetherjs/togetherjs.js
@@ -178,6 +178,7 @@
 
   var TogetherJS = window.TogetherJS = function TogetherJS(event) {
     if (TogetherJS.running) {
+      var session = TogetherJS.require("session");
       session.close();
       return;
     }


### PR DESCRIPTION
right now, if someone click the togetherjs button to close it and some closed variables are present, an exception will be thrown since TogetherJS() will load config before closing, I've altered that behavior by checking the running status in the beginning of the function(no need to reload config when togetherJS is being shutdown).

the other test in Config function is to make sure that closing and reopening TogetherJS does not fire the exception(since configuration will be reloaded), maybe we should add a return statement here?
