### PR TITLE
youtube module fix: onStateChange event target is not a complete player ...

### DIFF
--- a/site/examples/youtube/js/application.js
+++ b/site/examples/youtube/js/application.js
@@ -2,10 +2,12 @@ $(function () {
   $('.embed-submit-button').click(function() {
     // FIXME: uncaught exception: [CannotFind #video-id-input(:nth-child(1)): container only has 0 elements in #video-id-input]
     // I am not sure where this exception is generated. Maybe it is caused by togetherJS?
-    var newVideoId = $('video-id-input').val();
+    var newVideoId = $('#video-id-input').val();
     var newSrc = '//www.youtube.com/embed/' + newVideoId;
     var youTubeIframe = $('iframe')[0];
     $(youTubeIframe).attr("src", newSrc);
+    console.log("gonna run reinitailize now...");
+    //reinitialize to configure youtube players again
     TogetherJS.reinitialize();
   });
   $('video-id-input').keypress(function(event) {

--- a/togetherjs/youtubeVideos.js
+++ b/togetherjs/youtubeVideos.js
@@ -77,8 +77,9 @@ function ($, util, session, elementFinder) {
     function setupYouTubeIframes() {
       var iframes = $('iframe');
       iframes.each(function (i, iframe) {
-        // look for YouTube Iframes
         // if the iframe's unique id is already set, skip it
+        // FIXME: what if the user manually sets an iframe's id (i.e. "#my-youtube")?
+        // maybe we should set iframes everytime togetherjs is reinitialized?
         if (($(iframe).attr("src") || "").indexOf("youtube") != -1 && !$(iframe).attr("id")) {
           $(iframe).attr("id", "youtube-player"+i);
           $(iframe).attr("enablejsapi", 1);
@@ -104,8 +105,9 @@ function ($, util, session, elementFinder) {
   } // end of prepareYouTube
 
   function publishPlayerStateChange(event) {
-    var currentPlayer = event.target;
-    var currentIframe = currentPlayer.a;
+    var target = event.target; // WEIRD: target does not return a complete player object after reinitialze. (i.e. object without all the functions)
+    var currentIframe = target.a;
+    var currentPlayer = $(currentIframe).data("togetherjs-player"); // retrieve the player object from data as a workaround
     var currentTime = currentPlayer.getCurrentTime();
     var iframeLocation = elementFinder.elementLocation(currentIframe);
 


### PR DESCRIPTION
...object. A player is retrieved directly from the iframe instead of the event.

I found out my example application and the youtube module suddenly broke for some reason! I noticed that after the first reinitialization when another video was loaded, onStateChange event kept returning an incomplete player object that didn't have all the necessary functions. As a workaround, I simply retrieve a player object from the stored data attached to the iframe instead of event.target.

I am not sure if this problem has been recently introduced for whatever reason. Such issue was not present when I first committed the module and example. Weird!
