### PR TITLE
check for undefined  before calling $.each

### DIFF
--- a/togetherjs/forms.js
+++ b/togetherjs/forms.js
@@ -499,7 +499,7 @@ define(["jquery", "util", "session", "elementFinder", "eventMaker", "templating"
                                          msg.replace.delta.text);
       // apply this change to the history
       var changed = history.commit(msg.replace);
-      maybeSendUpdate(msg.element, history, tracker);
+      maybeSendUpdate(msg.element, history, tracker.trackerName);
       if (! changed) {
         return;
       }


### PR DESCRIPTION
calling `$.each` with `undefined` as argument throws an exception, I've added a guard to check for it.
the second commit is for adjusting tracker attribute to trackerName rather than the tracker object  when sending a message.
