### PR TITLE
Responsive drawing example

### DIFF
--- a/site/examples/drawing/index.html
+++ b/site/examples/drawing/index.html
@@ -20,7 +20,7 @@
         <a class="pull-right tjsbutton" onclick="TogetherJS(this); return false;">
           <img src="https://togetherjs.com/images/start-togetherjs-blue.png" style="width: 125px;"></img>
         </a>
-        <p class="pull-left" style="margin-bottom: 20px">This is a simple drawing example.  Try drawing something with a friend in the canvas below!  Check out this code on <a href="http://jsfiddle.net/5f8FL/" target="_blank">JSFiddle  here</a>.</p>
+        <p class="pull-left" style="margin-bottom: 20px">This is a simple drawing example.  Try drawing something with a friend in the canvas below!  Check out this code on <a href="http://jsfiddle.net/5f8FL/1/" target="_blank">JSFiddle  here</a>.</p>
         <div class="btn-group btn-group-justified" style="margin-left: auto; margin-right: auto;">
           <a class="btn btn-info color-picker upper-button">Blue</a>          
           <a class="btn btn-success color-picker">Green</a>

--- a/site/examples/drawing/js/sketch.js
+++ b/site/examples/drawing/js/sketch.js
@@ -67,7 +67,7 @@ function clear(send) {
   }
 }
 
-// Redraws the lines from an the lines-array:
+// Redraws the lines from the lines-array:
 function reDraw(lines){
   for (var i in lines) {
     draw(lines[i][0], lines[i][1], lines[i][2], lines[i][3], lines[i][4], false);
@@ -78,7 +78,7 @@ function draw(start, end, color, size, compositeOperation, save) {
   context.save();
   context.lineJoin = 'round'; 
   context.lineCap = 'round';
-  // Since the coordinates have been translated to a 1140x400 canvas, the context needs to be scaled before it can be drawn on:
+  // Since the coordinates have been translated to an 1140x400 canvas, the context needs to be scaled before it can be drawn on:
   context.scale(canvas.width/1140,canvas.height/400);
   context.strokeStyle = color;
   context.globalCompositeOperation = compositeOperation;
@@ -193,7 +193,6 @@ $(document).ready(function () {
       oWidth = canvas.width;
       oHeight = canvas.height;
       reDraw(lines);
-      context.restore();
       changeMouse();
     }
   });


### PR DESCRIPTION
Further improves the drawing example from the last [pull request](https://github.com/mozilla/togetherjs/pull/933) by making the canvas work properly on all screen sizes. Can be tested by resizing [this](http://fiddle.jshell.net/5f8FL/show/) window. Also works when the users have different window sizes, as the drawings are scaled with the original canvas size 1140x400 as a baseline.

JSFiddle: http://jsfiddle.net/5f8FL/

**Other changes:**
- Init now works by sending a list containing the info of all drawn lines, faster and more convenient than sending the canvas.toDataURL('image/png')-info.
- Clear-button for erasing the entire canvas introduced.

**Screenshot:** 
![image](https://f.cloud.github.com/assets/3536982/1720059/298d6212-61f7-11e3-9021-a14f6f9b4f52.png)
