### PR TITLE
youtube currentTime error fixed

### DIFF
--- a/togetherjs/youtubeVideos.js
+++ b/togetherjs/youtubeVideos.js
@@ -105,10 +105,14 @@ function ($, util, session, elementFinder) {
   } // end of prepareYouTube
 
   function publishPlayerStateChange(event) {
-    var target = event.target; // WEIRD: target does not return a complete player object after reinitialze. (i.e. object without all the functions)
+    var target = event.target; 
     var currentIframe = target.a;
-    var currentPlayer = $(currentIframe).data("togetherjs-player"); // retrieve the player object from data as a workaround
-    var currentTime = currentPlayer.getCurrentTime();
+    // FIXME: player object retrieved from event.target has an incomplete set of essential functions
+    // this is most likely due to a recently-introduced problem with current YouTube API as others have been reporting the same issue (12/18/`13)
+    //var currentPlayer = target;
+    //var currentTime = currentPlayer.getCurrentTime();
+    var currentPlayer = $(currentIframe).data("togetherjs-player");
+    var currentTime = target.k.currentTime;
     var iframeLocation = elementFinder.elementLocation(currentIframe);
 
     if ($(currentPlayer).data("seek")) {


### PR DESCRIPTION
There seems to be a problem with the current version of YouTube API, and this is another workaround to solve the issue. Since a player object stored as a jQuery data does not update its currentTime, it's necessary to get the information from the `event` object. Once the API is fixed, we will be able to use the more natural way of handling this (the part that's commented out for now).

Other people on Google forum have been reporting the same issue: [link](https://code.google.com/p/gdata-issues/issues/detail?id=5675&q=label%3AAPI-YouTube%20event.target&colspec=API%20ID%20Type%20Status%20Priority%20Stars%20Summary)
