### PR TITLE
Cannot read property 'trackerName' of undefined

### DIFF
--- a/togetherjs/forms.js
+++ b/togetherjs/forms.js
@@ -499,7 +499,11 @@ define(["jquery", "util", "session", "elementFinder", "eventMaker", "templating"
                                          msg.replace.delta.text);
       // apply this change to the history
       var changed = history.commit(msg.replace);
-      maybeSendUpdate(msg.element, history, tracker.trackerName);
+      var trackerName = null;
+      if (typeof tracker != "undefined") {
+        trackerName = tracker.trackerName;
+      }
+      maybeSendUpdate(msg.element, history, trackerName);
       if (! changed) {
         return;
       }


### PR DESCRIPTION
The error "Cannot read property 'trackerName' of undefined" is thrown anytime we try to write in a input or textarea element. The bug is visible on the online demos "Mad Libs" and "Grocery to do app" at https://togetherjs.com/.
