### PR TITLE
Handle Windows slashes in paths

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -315,6 +315,7 @@ module.exports = function (grunt) {
       if (tmplVars.absoluteLinks) {
         tmplVars.base = "/";
       }
+      tmplVars.base = tmplVars.base.replace(/\\/g, '/');
       var tmpl = env.getTemplate(source);
       var result = tmpl.render(tmplVars);
       grunt.file.write(dest, result);
@@ -398,6 +399,7 @@ module.exports = function (grunt) {
       if (tmplVars.base && tmplVars.base.search(/\/$/) == -1) {
         tmplVars.base += "/";
       }
+      tmplVars.base = tmplVars.base.replace(/\\/g, '/');
       var result = tmpl.render(tmplVars);
       grunt.file.write(dest, result);
     });


### PR DESCRIPTION
If I try building on Windows, path.relative() returns a path with backslashes in it. This breaks stylesheet and script links, since the web server expects only forward slashes. This is fixed below by replacing backslashes with forward slashes whenever path.relative is used in the gruntfile.
