### PR TITLE
#963 peers.url should be peer.url

### DIFF
--- a/togetherjs/ui.js
+++ b/togetherjs/ui.js
@@ -953,7 +953,7 @@ define(["require", "jquery", "util", "session", "templates", "templating", "link
         return false;
       });
       el.find(".togetherjs-follow").click(function () {
-        var url = attrs.peers.url;
+        var url = attrs.peer.url;
         if (attrs.peer.urlHash) {
           url += attrs.peer.urlHash;
         }


### PR DESCRIPTION
peer is now resolved and error goes away.

![image](https://f.cloud.github.com/assets/1424580/2349024/e8daeea0-a55e-11e3-8342-d3b4f31419de.png)
