### PR TITLE
updated youtube module in response to google issue 5670

### DIFF
--- a/togetherjs/youtubeVideos.js
+++ b/togetherjs/youtubeVideos.js
@@ -82,7 +82,9 @@ function ($, util, session, elementFinder) {
         // maybe we should set iframes everytime togetherjs is reinitialized?
         if (($(iframe).attr("src") || "").indexOf("youtube") != -1 && !$(iframe).attr("id")) {
           $(iframe).attr("id", "youtube-player"+i);
-          $(iframe).attr("enablejsapi", 1);
+          //$(iframe).attr("enablejsapi", 1);
+          var addedParam = "?enablejsapi=1&origin="+window.location.origin; //response to Google issue 5670
+          $(iframe).attr("src", $(iframe).attr("src") + addedParam); // if origin parameter is missing, onReady and playerStateChange event don't fire
           youTubeIframes[i] = iframe;
         }
       });


### PR DESCRIPTION
As a result of Youtube Iframe API's update, the player's important events, `onReady` and `onStateChange` do not fire unless `origin` parameter is set as `window.location.origin` in the iframe's src. This is a result of Google issue [5670](https://code.google.com/p/gdata-issues/issues/detail?id=5670). This commit fixes the issue by specifying the origin when initializing iframe players.

The example page isn't working because of this issue, but this commit will fix it.
