### PR TITLE
Translator helper for chat

### DIFF
--- a/togetherjs/chat.js
+++ b/togetherjs/chat.js
@@ -2,12 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 /*jshint evil:true */
-define(["require", "jquery", "util", "session", "ui", "templates", "playback", "storage", "peers", "windowing"], function (require, $, util, session, ui, templates, playback, storage, peers, windowing) {
+define(["require", "jquery", "util", "session", "ui", "templates", "playback", "storage", "peers", "windowing", "translator"], function (require, $, util, session, ui, templates, playback, storage, peers, windowing, translator) {
   var chat = util.Module("chat");
   var assert = util.assert;
   var Walkabout;
 
   session.hub.on("chat", function (msg) {
+    // FIXME: Currently forcing translation from en -> pt
+    translator.translate(msg.text, 'en', 'pt', function(translation){
+      msg.translation = translation;
+      ui.chat.updateTextWithTranslation(msg);
+    });
     ui.chat.text({
       text: msg.text,
       peer: msg.peer,

--- a/togetherjs/translator.js
+++ b/togetherjs/translator.js
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+define(["require", "jquery", "util"], function (require, $, util) {
+  var translator = util.Module("translator");
+  var assert = util.assert;
+
+  //FIXME: Read API key from config env
+  //Simon's severely limited API key
+  translator.apiKey = "AIzaSyDoLqBvTaoeCytNtJC2gJUGoWhPi6kMLLg";
+
+  translator.translate = function(text, source, target, callback){
+    var apiurl = "https://www.googleapis.com/language/translate/v2?key=" + translator.apiKey +
+      "&source=" + source +
+      "&target=" + target +
+      "&q=";
+
+    $.ajax({
+      url: apiurl + encodeURIComponent(text),
+      dataType: 'jsonp',
+      success: function(data) {
+        if (typeof callback === 'function'){
+          // TODO: Emit array of translations
+          callback(data.data.translations[0].translatedText);
+        }
+      }
+    });
+  }
+
+  translator.detect = function(text){
+  }
+
+  return translator;
+});
+

--- a/togetherjs/ui.js
+++ b/togetherjs/ui.js
@@ -883,6 +883,12 @@ define(["require", "jquery", "util", "session", "templates", "templating", "link
         .attr("data-message-id", attrs.messageId);
       ui.chat.add(el, attrs.messageId, attrs.notify);
     },
+    updateTextWithTranslation: function(attrs){
+      assert(typeof attrs.translation == "string");
+      assert(attrs.messageId);
+
+      $("[data-message-id='" + attrs.messageId + "'] .togetherjs-chat-content").text(attrs.translation);
+    },
 
     joinedSession: function (attrs) {
       assert(attrs.peer);


### PR DESCRIPTION
- [x] Hack it in there ( http://downloads.simonwex.com/grabs/TogetherJS-Local.mp4 )
- [ ] Set API key as env configuration
- [ ] Choose the locale you want it translated into (defaulting to your browser's locale)
- [ ] Ability to turn on/off translation
- [ ] Signalling that your messages are being translated
- [ ] Signalling that the message you're reading was translated
- [ ] Access to the original, unstranslated message
- [ ] When viewing a translated message, have a way to give quick feedback to say something seems to be failing in the translation (say it differently/use different words)
- [ ] Fix the bug that causes only the first message in a window to be translated.
