### PR TITLE
Tinymce editor improvements: more generic textarea usecases and realtime...

### DIFF
--- a/togetherjs/forms.js
+++ b/togetherjs/forms.js
@@ -780,6 +780,9 @@ define(["jquery", "util", "session", "elementFinder", "eventMaker", "templating"
   var focusElements = {};
 
   session.hub.on("form-focus", function (msg) {
+    if (! msg.sameUrl) {
+      return;
+    }
     var current = focusElements[msg.peer.id];
     if (current) {
       current.remove();


### PR DESCRIPTION
I first ended up diving into the code, because the tracking wasn't working when the textarea's @id wasn't of the form mce_...  -- that's any textarea where the textarea already had an id tag when tinymce was loaded.

However, the togetherjs code was so fun to hack, I thought it would be fun to add real-time cursor positioning.
