### PR TITLE
Update New Relic agent to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ejs-locals": "~1.0.2",
     "universal-analytics": "~0.1.3",
     "less-middleware": "~0.1.9",
-    "newrelic": "0.9.20",
+    "newrelic": "~1.7.0",
     "grunt-amd-check": "~0.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
We're using 0.9 New Relic, which has been upgraded all the way to 1.7.0.  Want to give that a shot?