### PR TITLE
Compatability with marked 0.2.10 and docco 0.6.3.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -317,9 +317,9 @@ module.exports = function (grunt) {
   });
 
   function parseMarkdownOutput(doc) {
-    var title = (/<h1>(.*)<\/h1>/i).exec(doc);
+    var title = (/<h1[^>]*>(.*)<\/h1>/i).exec(doc);
     title = title[1];
-    var body = doc.replace(/<h1>.*<\/h1>/i, "");
+    var body = doc.replace(/<h1[^>]*>.*<\/h1>/i, "");
     return {
       title: title,
       body: body
@@ -426,7 +426,7 @@ module.exports = function (grunt) {
       var dest = grunt.option("dest") + "/source/" + source + ".html";
       grunt.log.writeln("Rendering " + source.cyan + " to " + dest.cyan);
       var code = grunt.file.read("togetherjs/" + source);
-      var sections = docco.parse(source, code);
+      var sections = docco.parse(source, code, {languages:{}});
       doccoFormat(source, sections);
       sections.forEach(function (section, i) {
         section.index = i;


### PR DESCRIPTION
The `<h1>` tags in `marked` 0.2.10 contain the `id` attributes which we were
manually adding in the grunt `addHeaderIds` function, causing the match in
`parseMarkdownOutput` to fail (and grunt to crash).  Allow `<h1>` tags to
contain (simple) attributes.

In docco 0.6.3, the `docco.parse` function added an optional `config`
parameter, but docco crashes if you use the default value.  Filed and
patched upstream in https://github.com/jashkenas/docco/pull/291 -- but
work around this for now by passing `{languages:{}}` as the third
parameter (which is safely ignored in docco 0.6.2).
