### PR TITLE
Fix grunt builds to non-default destinations.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -81,7 +81,7 @@ module.exports = function (grunt) {
   grunt.file.expand("togetherjs/locale/*.json").forEach(function (langFilename) {
     var lang = path.basename(langFilename).replace(/\.json/, "");
     libs.push("templates-" + lang);
-    requirejsPaths["templates-" + lang] = "../build/togetherjs/templates-" + lang;
+    requirejsPaths["templates-" + lang] = path.join("..", grunt.option("dest"), "togetherjs", "templates-" + lang);
   });
 
   grunt.initConfig({
@@ -142,7 +142,7 @@ module.exports = function (grunt) {
       options: {
         csslintrc: ".csslint.rc"
       },
-      src: ["build/togetherjs/togetherjs.css"]
+      src: [path.join(grunt.option("dest"), "togetherjs/togetherjs.css")]
     },
 
     watch: {


### PR DESCRIPTION
The `build` and `csslint` targets were using "build" as the destination,
even if a different one was specified on the command line.
