### PR TITLE
Allow end-user configuration of baseUrl.

### DIFF
--- a/togetherjs/togetherjs.js
+++ b/togetherjs/togetherjs.js
@@ -70,6 +70,8 @@
     ignoreMessages: ["cursor-update", "keydown", "scroll-update"],
     // Ignores the following forms (will ignore all forms if set to true):
     ignoreForms: [":password"],
+    // When undefined, attempts to use the browser's language
+    lang: undefined,
     fallbackLang: "en_US"
   };
 


### PR DESCRIPTION
This makes it easier to use a local copy of TogetherJS, without requiring a rebuild from sources.
