### PR TITLE
change the LocaleTemplates at line 317 in togetherjs.js

### DIFF
--- a/togetherjs/togetherjs.js
+++ b/togetherjs/togetherjs.js
@@ -315,8 +315,8 @@
     TogetherJS.config("lang", lang.replace(/_/g, "-")); // rename into TogetherJS.config.get()?
     //var localeTemplates = "templates-" + lang;// rename into TogetherJS.config.get()?
     //lang.replace(/_/g, "-") doesn't work for variable "lang", the "lang" doesn't change. So "lang" would be en_US. Should use the config value.
-	var localeTemplates = "templates-" + TogetherJS.getConfig("lang");
-	deps.splice(0, 0, localeTemplates);
+    var localeTemplates = "templates-" + TogetherJS.getConfig("lang");
+    deps.splice(0, 0, localeTemplates);
     function callback(session, jquery) {
       TogetherJS._loaded = true;
       if (! min) {

--- a/togetherjs/togetherjs.js
+++ b/togetherjs/togetherjs.js
@@ -313,8 +313,10 @@
     }
 
     TogetherJS.config("lang", lang.replace(/_/g, "-")); // rename into TogetherJS.config.get()?
-    var localeTemplates = "templates-" + lang;// rename into TogetherJS.config.get()?
-    deps.splice(0, 0, localeTemplates);
+    //var localeTemplates = "templates-" + lang;// rename into TogetherJS.config.get()?
+    //lang.replace(/_/g, "-") doesn't work for variable "lang", the "lang" doesn't change. So "lang" would be en_US. Should use the config value.
+	var localeTemplates = "templates-" + TogetherJS.getConfig("lang");
+	deps.splice(0, 0, localeTemplates);
     function callback(session, jquery) {
       TogetherJS._loaded = true;
       if (! min) {


### PR DESCRIPTION
There is a bug in file togetherjs.js: When it request the templates-en-US, I found in console it was an error "templates do not load". Using the FireBug it shows the file request "templates-en_US", so in togetherjs.js the variable LocaleTemplates at line 317 was wrong. I changed it with new "lang" in the TogetherConfig which has been changed.
