### PR TITLE
Fixing IE 11 inherit issues #1017

### DIFF
--- a/togetherjs/functions.less
+++ b/togetherjs/functions.less
@@ -25,7 +25,6 @@
 // The CSS reset doesn't reset everything, just resets them to normal.
 // This resets buttons back to nothing.
 .button-reset () {
-  background-color: inherit;
   border: none;
   padding: 0;
   margin: 0;

--- a/togetherjs/togetherjs.less
+++ b/togetherjs/togetherjs.less
@@ -208,7 +208,7 @@ input.togetherjs-upload-avatar {
 
 .togetherjs-cancel {
   display: inline-block;
-  background: inherit;
+  background-color: @background-color;
   border: none;
   padding:3px 0px;
   margin:0px 0px 0px;
@@ -278,6 +278,7 @@ input.togetherjs-upload-avatar {
     float: right;
     font-weight: bold;
     cursor: pointer;
+    background-color: @background-color;
     background-image: url('./images/icon-close@2x.png');
     background-position:center center;
     background-repeat: no-repeat;
@@ -316,6 +317,7 @@ input.togetherjs-upload-avatar {
     position: relative;
     width: @button-size+20;
     height: @button-size+20;
+    background-color: @background-color;
     background-size: @button-size @button-size;
     background-repeat: no-repeat;
     background-position: center;


### PR DESCRIPTION
    .button-reset () { 
      background-color: inherit; 
    ...

    .togetherjs-cancel {
      background-color: inherit;
    ...

Does not work in IE 11 so they are replaced with `background-color: @background-color;`. 

See #1017