### PR TITLE
#1033 - Fix YouTube sync when loading a different video (on the example page)

### DIFF
--- a/site/examples/youtube/js/application.js
+++ b/site/examples/youtube/js/application.js
@@ -3,12 +3,16 @@ $(function () {
     // FIXME: uncaught exception: [CannotFind #video-id-input(:nth-child(1)): container only has 0 elements in #video-id-input]
     // I am not sure where this exception is generated. Maybe it is caused by togetherJS?
     var newVideoId = $('#video-id-input').val();
-    var newSrc = '//www.youtube.com/embed/' + newVideoId;
-    var youTubeIframe = $('iframe')[0];
-    $(youTubeIframe).attr("src", newSrc);
-    console.log("gonna run reinitailize now...");
-    //reinitialize to configure youtube players again
-    TogetherJS.reinitialize();
+    var $youTubeIframe = $("iframe[src*='youtube']");
+    var player = $youTubeIframe.data('togetherjs-player');
+    player.loadVideoById(newVideoId);
+
+    // If the iframe's src is changed, the saved youtube player malfunctions
+    
+    // $(youTubeIframe).attr("src", newSrc);
+    // console.log("gonna run reinitailize now...");
+    // //reinitialize to configure youtube players again
+    // TogetherJS.reinitialize();
   });
   $('video-id-input').keypress(function(event) {
     if (event.keyCode == 13)

--- a/togetherjs/youtubeVideos.js
+++ b/togetherjs/youtubeVideos.js
@@ -36,12 +36,14 @@ function ($, util, session, elementFinder) {
     });
   });
 
-  TogetherJS.config.track("youtube", function (track, previous) {
-    if (track && ! previous) {
-      prepareYouTube();
-      // You can enable youtube dynamically, but can't turn it off:
-      TogetherJS.config.close("youtube");
-    }
+  $(function() {
+    TogetherJS.config.track("youtube", function (track, previous) {
+      if (track && ! previous) {
+        prepareYouTube();
+        // You can enable youtube dynamically, but can't turn it off:
+        TogetherJS.config.close("youtube");
+      }
+    });
   });
 
   var youtubeHooked = false;


### PR DESCRIPTION
This PR also addresses calling "prepareYouTube()" function before the iframe element is ready.
