### PR TITLE
Add server-echo to client to keep connection alive

### DIFF
--- a/togetherjs/session.js
+++ b/togetherjs/session.js
@@ -445,7 +445,18 @@ define(["require", "util", "channels", "jquery", "storage"], function (require, 
     });
   };
 
+  var activeTimeout;
+  var pingTimeout = function() {
+    return (40 * 1000) + (Math.random() * 20 - 10); // 40 s +/- 10s
+  };
+  var pingTheHub = function() {
+    activeTimeout = setTimeout(pingTheHub, pingTimeout());
+    session.send({"server-echo": true});
+  };
+
   session.on("start", function () {
+    pingTheHub();
+
     $(window).on("resize", resizeEvent);
     if (includeHashInUrl) {
       $(window).on("hashchange", hashchangeEvent);
@@ -453,6 +464,8 @@ define(["require", "util", "channels", "jquery", "storage"], function (require, 
   });
 
   session.on("close", function () {
+    clearTimeout(activeTimeout);
+
     $(window).off("resize", resizeEvent);
     if (includeHashInUrl) {
       $(window).off("hashchange", hashchangeEvent);

--- a/togetherjs/session.js
+++ b/togetherjs/session.js
@@ -447,7 +447,7 @@ define(["require", "util", "channels", "jquery", "storage"], function (require, 
 
   var activeTimeout;
   var pingTimeout = function() {
-    return (40 * 1000) + (Math.random() * 20 - 10); // 40 s +/- 10s
+    return (40 + Math.random() * 20 - 10) * 1000; // 40 s +/- 10s
   };
   var pingTheHub = function() {
     activeTimeout = setTimeout(pingTheHub, pingTimeout());


### PR DESCRIPTION
Heroku has an initial 30s request timeout which extends to a 55s rolling window request timeout. This patch will have the client periodically send data to the hub server, keeping the WebSocket connection alive.
