### PR TITLE
A Session's channel is now able to be retrieved correctly. (Related to #57)

### DIFF
--- a/togetherjs/session.js
+++ b/togetherjs/session.js
@@ -419,6 +419,10 @@ define(["require", "util", "channels", "jquery", "storage"], function (require, 
     });
   };
 
+  session._getChannel = function () {
+      return channel;
+    };
+
   session.close = function (reason) {
     TogetherJS.running = false;
     var msg = {type: "bye"};


### PR DESCRIPTION
This pull / merge request is related to the an issue described in #57. (It probably deserves it's own GitHub Issue itself.) Playback of mouse events was being entirely prevented due to Session ClassObjects being unable to retrieve channels for a peer. An error was reported on Line 155 in playback.js whenever the system tried to replay a mouse event. I tested this in both Chrome and Firefox.

I supplied a fix by explicitly defining the `_getChannel` method for Session ClassObjects (in session.js). As I'm far less familiar with the codebase, there is probably a more elegant solution. Nevertheless, this fix does restore functionality for playing back mouse events. 

If you have any questions, please feel free to get back to me here. Looking forward to contributing more!
