### PR TITLE
Update to secure version of Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "grunt-lib-phantomjs": "~0.6.0"
   },
   "engines": {
-    "node": "~0.12.7",
-    "npm": "^2.11.3"
+    "node": "^4.8.4",
+    "npm": "^2.15.11"
   },
   "scripts": {
     "start": "node hub/server.js",


### PR DESCRIPTION
I don't know if this will even work, but let's try to make sure this at least needs to build on a secure version of Node LTS